### PR TITLE
EntityType restrictions on Tiles

### DIFF
--- a/Assets/ScriptableObjects/GridMaps/SampleGridMap.asset
+++ b/Assets/ScriptableObjects/GridMaps/SampleGridMap.asset
@@ -19,74 +19,93 @@ MonoBehaviour:
   - Controller: {fileID: 0}
     Coordinates: {x: 1, y: 1}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: 2, y: 1}
     IsEnabled: 1
-    _occupants: []
+    AllowedOccupanTypes: 5
+    _occupants:
+    - {fileID: 6808603951770585064, guid: 64ecfc7ad7a6c584b80bff5866ac1425, type: 3}
   - Controller: {fileID: 0}
     Coordinates: {x: 3, y: 1}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -1, y: 1}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -2, y: 1}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -3, y: 1}
-    IsEnabled: 0
+    IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: 1, y: 2}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants:
     - {fileID: 365454816790848774, guid: be6e7d7af7aff3b4495cad736eb51845, type: 3}
   - Controller: {fileID: 0}
     Coordinates: {x: 2, y: 2}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: 3, y: 2}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -1, y: 2}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -2, y: 2}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -3, y: 2}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: 1, y: 3}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: 2, y: 3}
     IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: 3, y: 3}
-    IsEnabled: 0
+    IsEnabled: 1
+    AllowedOccupanTypes: 5
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -1, y: 3}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants:
-    - {fileID: 365454816790848774, guid: be6e7d7af7aff3b4495cad736eb51845, type: 3}
+    - {fileID: 6808603951770585064, guid: 2be73b83d65f53d4289a9f3710673572, type: 3}
   - Controller: {fileID: 0}
     Coordinates: {x: -2, y: 3}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []
   - Controller: {fileID: 0}
     Coordinates: {x: -3, y: 3}
     IsEnabled: 1
+    AllowedOccupanTypes: 6
     _occupants: []

--- a/Assets/Scripts/Editor/GridMapEditor.cs
+++ b/Assets/Scripts/Editor/GridMapEditor.cs
@@ -194,7 +194,7 @@ public class GridMapEditor : Editor
     private void DrawTileDetails(GridTileData tile)
     {
         // Validate
-        if (tile == null || (tile.X == 0 && tile.Y == 0))
+        if (tile == null || !((GridMap)target).Tiles.Contains(tile))
         {
             EditorGUILayout.LabelField("No tile selected");
             return;

--- a/Assets/Scripts/Editor/GridMapEditor.cs
+++ b/Assets/Scripts/Editor/GridMapEditor.cs
@@ -202,7 +202,10 @@ public class GridMapEditor : Editor
 
         // Display Basic Data
         EditorGUILayout.LabelField("Coordinates", $"X: {tile.X}, Y: {tile.Y}");
-        EditorGUILayout.LabelField("Type", tile.X > 0 ? "Ally Tile" : "Enemy Tile");
+
+        IEnumerable<string> entityFilter = EnumExtensions.GetMatchingFlags<GridEntityCategory>((int)tile.AllowedOccupanTypes).Select(flag => flag.ToString());
+        EditorGUILayout.LabelField("Entity Types Allowed", $"[{string.Join(", ", entityFilter)}]");
+
         tile.IsEnabled = EditorGUILayout.Toggle("Enabled", tile.IsEnabled);
 
         if (!tile.IsEnabled) return;
@@ -224,9 +227,13 @@ public class GridMapEditor : Editor
         {
             EditorGUILayout.BeginHorizontal();
 
-            // Validate occupant and get its name
+            // Validate occupant
             bool occupantExists = occupants[i] != null;
-            string occupantName = occupantExists ? occupants[i].UserFriendlyName : "Missing occupant reference";
+
+            // Get occupant's name
+            string occupantName = "<UserFriendlyName>";
+            if (!occupantExists) occupantName = "Missing occupant reference";
+            else if (occupants[i] is Character character) occupantName = character.CharacterProfile.Name;
 
             // Mark red, if an occupant is missing
             Color previousColor = GUI.color;

--- a/Assets/Scripts/Extensions/EnumExtensions.cs
+++ b/Assets/Scripts/Extensions/EnumExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq;
+
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Translates an int describing a flag-type enum, into an array of maching enum entries
+    /// </summary>
+    /// <param name="input">Int describing a flag-type enum</param>
+    /// <typeparam name="T">Enum type</typeparam>
+    /// <returns>An array of matching enum entires</returns>
+    public static T[] GetMatchingFlags<T>(this int input) where T : Enum
+    {
+        // Get all possible enum values except the default value (e.g., 'None')
+        var allFlags = Enum.GetValues(typeof(T))
+                           .Cast<T>()
+                           .Where(f => !f.Equals(default(T)))
+                           .ToArray();
+
+        // Check which flags are set in the input number
+        var matchingFlags = allFlags.Where(f => (input & Convert.ToInt32(f)) == Convert.ToInt32(f)).ToArray();
+
+        // If no flags are set, return an array with the default value (e.g., 'None')
+        return matchingFlags.Length > 0 ? matchingFlags : new T[] { default };
+    }
+}

--- a/Assets/Scripts/Extensions/EnumExtensions.cs.meta
+++ b/Assets/Scripts/Extensions/EnumExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db2d3615e08731349af18d4869cc974f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Grid/GridMap.cs
+++ b/Assets/Scripts/Grid/GridMap.cs
@@ -77,19 +77,19 @@ public class GridMap : ScriptableObject
         {
             for (int x = 1; x <= WidthL; x++)
             {
-                InitializeTile(x, y);
+                InitializeTile(x, y, GridEntityCategory.Ally | GridEntityCategory.Object);
             }
 
             for (int x = 1; x <= WidthR; x++)
             {
-                InitializeTile(-x, y);
+                InitializeTile(-x, y, GridEntityCategory.Enemy | GridEntityCategory.Object);
             }
         }
 
         if (removeUnusedTiles) OptimizeGrid();
     }
 
-    private void InitializeTile(int x, int y)
+    private void InitializeTile(int x, int y, GridEntityCategory entityFilter)
     {
         Vector2 index = new(x, y);
 
@@ -97,8 +97,8 @@ public class GridMap : ScriptableObject
         GridTileData existingTile = this[index];
         if (existingTile != null) return;
 
-        // Add a new tile if it doesn't exist
-        GridTileData newTile = new(x, y);
+        // Add a new tile if it doesn't exist or is invalid
+        GridTileData newTile = new(x, y, entityFilter);
         Tiles.Add(newTile);
     }
 

--- a/Assets/Scripts/Grid/GridTileData.cs
+++ b/Assets/Scripts/Grid/GridTileData.cs
@@ -9,12 +9,14 @@ public class GridTileData
 {
     public GridMap Map { get => GridManager.Instance.Grid; }
 
+    public int X { get => Coordinates.x; }
+    public int Y { get => Coordinates.y; }
+
     public GridTileController Controller;
 
     public Vector2Int Coordinates;
-    public int X { get => Coordinates.x; }
-    public int Y { get => Coordinates.y; }
     public bool IsEnabled;
+    public GridEntityCategory AllowedOccupanTypes;
 
     #region Neighbours
 
@@ -46,11 +48,12 @@ public class GridTileData
 
     #region Constructor
 
-    public GridTileData(Vector2Int coordinates) : this(coordinates.x, coordinates.y) { }
-    public GridTileData(int x, int y)
+    public GridTileData(Vector2Int coordinates, GridEntityCategory allowedOccupanTypes) : this(coordinates.x, coordinates.y, allowedOccupanTypes) { }
+    public GridTileData(int x, int y, GridEntityCategory allowedOccupanTypes)
     {
         Coordinates = new(x, y);
         IsEnabled = true;
+        AllowedOccupanTypes = allowedOccupanTypes;
     }
 
     #endregion


### PR DESCRIPTION
Now, when generating GridMaps, each tile is assigned a GridEntityCategory filter, which in the future development will determine the tiles an entity can move to or be placed on.